### PR TITLE
Remove loop

### DIFF
--- a/shc/supervisor.py
+++ b/shc/supervisor.py
@@ -25,7 +25,7 @@ _REGISTERED_INTERFACES: Set["AbstractInterface"] = set()
 
 event_loop = asyncio.get_event_loop()
 _EXIT_CODE = 0
-_SHC_STOPPED = asyncio.Event(loop=event_loop)
+_SHC_STOPPED = asyncio.Event()
 _SHC_STOPPED.set()
 
 


### PR DESCRIPTION
With Python 3.10 the examples don't run.

```bash
$ python example/ui_simple.py 
Traceback (most recent call last):
  File "/home/fab/Documents/repos/smarthomeconnect/example/ui_simple.py", line 4, in <module>
    import shc
  File "/home/fab/Documents/repos/smarthomeconnect/shc/__init__.py", line 13, in <module>
    from . import supervisor
  File "/home/fab/Documents/repos/smarthomeconnect/shc/supervisor.py", line 28, in <module>
    _SHC_STOPPED = asyncio.Event(loop=event_loop)
  File "/usr/lib64/python3.10/asyncio/locks.py", line 167, in __init__
    super().__init__(loop=loop)
  File "/usr/lib64/python3.10/asyncio/mixins.py", line 17, in __init__
    raise TypeError(
TypeError: As of 3.10, the *loop* parameter was removed from Event() since it is no longer necessary
```

Removing the loop fixes the issue for me on Python 3.10. I haven't tested other Python releases so far.

It was [deprecated](https://docs.python.org/3/library/asyncio-sync.html?highlight=event#event) in Python 3.8. `setup.py` says min. requirement is [3.7](https://github.com/mhthies/smarthomeconnect/blob/main/setup.py#L43) which might be a problem.