### PR TITLE
Replace pycodestyle with flake8 and fix (nearly) all issues found by it

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+exclude=
+    .cache,
+    .git,
+    dist,
+    docs,
+    htmlcov,
+    node_modules,
+    venv,
+    venv*,
+    .mypy_cache,
+    test/assets
+max-line-length=120
+per-file-ignores=
+    */__init__.py:F401
+    example/*:F403,F405

--- a/.flake8
+++ b/.flake8
@@ -10,7 +10,8 @@ exclude=
     venv*,
     .mypy_cache,
     test/assets
-max-line-length=120
 per-file-ignores=
     */__init__.py:F401
     example/*:F403,F405
+max-line-length=120
+max-complexity=15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,14 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pycodestyle mypy
+        pip install flake8 mypy
         pip install -r requirements.txt
     - name: Check typing with MyPy
       run: |
         mypy
-    - name: Check code style with PyCodestyle
+    - name: Check code style with flake8
       run: |
-        pycodestyle --max-line-length 120 shc/ test/ example/
+        flake8
 
   package:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Please, consult the [documentation](https://smarthomeconnect.readthedocs.io/en/l
 
 If you want to help with the development of *Smart Home Connect*, your Pull Requests are always appreciated.
 
+### Development setup
+
 Setting up a dev environment for SHC is simple:
 Clone the git repository and install the development dependencies, listed in `requirements.txt` (+ the `python-rtmidi` module if you want to run the MIDI tests).
 These include all dependencies of smarthomeconnect with all extras:
@@ -213,6 +215,9 @@ pip3 install -r requirements.txt
 pip3 install python-rtmidi
 ```
 You may want to use a virtual environment to avoid messing up your Python packages.
+
+
+### Web UI Frontend Assets
 
 Additionally, you'll need NodeJS and NPM on your machine for downloading and packing the web UI frontend asset  files.
 Use the following commands to download all frontend dependencies from NPM and package them into `/shc/web/static` (using Parcel.js):
@@ -225,6 +230,9 @@ When working on the web UI source files themselves (which are located in `web_ui
 npx parcel web_ui_src/main.js --dist-dir shc/web/static/pack --public-url ./
 ```
 
+
+### Tests and Code Style
+
 Please make sure that all the unittests are passing, when submitting a Pull Request:
 ```bash
 python3 -m unittest
@@ -236,4 +244,10 @@ To check it, you may want to determine it locally, using the `coverage` tool:
 ```bash
 coverage run -m unittest
 coverage html
+# open htmlcov/index.html
 ``` 
+
+We also enforce static type correctness with MyPy and Python codestyle rules with flake8.
+To run the static type checks and codestyle checks locally, simply install MyPy and flake8 and execute the `mypy` and `flake8` commands in the shc project repository.
+
+All these checks are also performed by the GitHub Actions CI for Pull Requests and the master branch.

--- a/example/ui_showcase.py
+++ b/example/ui_showcase.py
@@ -20,7 +20,6 @@ Some things to note:
 """
 import random
 import enum
-from pathlib import Path
 
 import markupsafe
 

--- a/shc/base.py
+++ b/shc/base.py
@@ -16,7 +16,7 @@ import functools
 import inspect
 import logging
 import random
-from typing import Generic, List, Any, Tuple, Callable, Optional, Type, TypeVar, Awaitable, Union, Dict, Set
+from typing import Generic, List, Any, Tuple, Callable, Optional, Type, TypeVar, Awaitable, Union, Dict
 
 from . import conversion
 

--- a/shc/expressions.py
+++ b/shc/expressions.py
@@ -20,7 +20,7 @@ from typing import Type, Generic, Any, Iterable, Callable, Union, Dict, Tuple, L
 
 from . import conversion
 from .base import Readable, Subscribable, T, Connectable, Writable, S, LogicHandler, UninitializedError
-from .datatypes import RangeFloat1, RangeUInt8, HSVFloat1, RGBFloat1, RGBUInt8
+from .datatypes import RangeFloat1
 
 
 class ExpressionBuilder(Connectable[T], metaclass=abc.ABCMeta):

--- a/shc/interfaces/midi.py
+++ b/shc/interfaces/midi.py
@@ -16,7 +16,7 @@ from typing import List, Any, Tuple, Dict, Optional, Union, Iterable
 
 import mido
 
-from ..base import Subscribable, Writable, T
+from ..base import Subscribable, Writable
 from ..datatypes import RangeUInt8
 from ..supervisor import stop, AbstractInterface
 

--- a/shc/interfaces/mqtt.py
+++ b/shc/interfaces/mqtt.py
@@ -14,9 +14,9 @@ import collections
 import itertools
 import json
 import logging
-from typing import List, Any, Generic, Type, Callable, Awaitable, Optional, Tuple, Union, Dict, Deque
+from typing import List, Any, Generic, Type, Callable, Awaitable, Optional, Union, Dict, Deque
 
-from paho.mqtt.client import MQTTMessage, MQTTv311
+from paho.mqtt.client import MQTTMessage
 from asyncio_mqtt import Client, MqttError, ProtocolVersion
 from paho.mqtt.matcher import MQTTMatcher
 

--- a/shc/interfaces/pulse.py
+++ b/shc/interfaces/pulse.py
@@ -291,31 +291,15 @@ class PulseAudioInterface(SupervisedClientInterface):
 
         if event.t is PulseEventTypeEnum.new:
             if event.facility is PulseEventFacilityEnum.sink:
-                data = await self.pulse.sink_info(event.index)
-                name = data.name
-                for connector in self.sink_connectors_by_name.get(name, []):
-                    connector.change_id(event.index)
-                    self.sink_connectors_by_id[event.index].append(connector)
-                    connector.on_change(data, [])
+                await self.__on_event_new_sink(event.index)
             elif event.facility is PulseEventFacilityEnum.source:
-                data = await self.pulse.source_info(event.index)
-                name = data.name
-                for source_connector in self.source_connectors_by_name.get(name, []):
-                    source_connector.change_id(event.index)
-                    self.source_connectors_by_id[event.index].append(source_connector)
-                    source_connector.on_change(data, [])
+                await self.__on_event_new_source(event.index)
 
         elif event.t is PulseEventTypeEnum.remove:
             if event.facility is PulseEventFacilityEnum.sink:
-                for connector in self.sink_connectors_by_id.get(event.index, []):
-                    connector.change_id(None)
-                if event.index in self.sink_connectors_by_id:
-                    del self.sink_connectors_by_id[event.index]
+                await self.__on_event_remove_sink(event.index)
             elif event.facility is PulseEventFacilityEnum.source:
-                for source_connector in self.source_connectors_by_id.get(event.index, []):
-                    source_connector.change_id(None)
-                if event.index in self.source_connectors_by_id:
-                    del self.source_connectors_by_id[event.index]
+                await self.__on_event_remove_source(event.index)
 
         elif event.t is PulseEventTypeEnum.change:
             # Check if the event has probably been caused by a value update from SHC. In this case, we should have the
@@ -336,33 +320,64 @@ class PulseAudioInterface(SupervisedClientInterface):
                     source_connector.on_change(data, origin)
 
             elif event.facility is PulseEventFacilityEnum.server:
-                # For server change events, we need to update our default_*_name connectors and possibly change the
-                # current_id of all the default_sink/source_* connectors (and update them with the current state of the
-                # new default sink/source)
-                server_info = await self.pulse.server_info()
-                self._default_sink_name_connector._update(server_info, origin)
-                self._default_source_name_connector._update(server_info, origin)
-                # Update default sink/source connectors
-                default_sink_data = await self.pulse.get_sink_by_name(server_info.default_sink_name)
-                default_source_data = await self.pulse.get_source_by_name(server_info.default_source_name)
-                for connector in self.sink_connectors_by_name.get(None, []):
-                    if connector.current_id is not None:
-                        try:
-                            self.sink_connectors_by_id[connector.current_id].remove(connector)
-                        except ValueError:
-                            pass
-                    connector.change_id(default_sink_data.index)
-                    self.sink_connectors_by_id[default_sink_data.index].append(connector)
-                    connector.on_change(default_sink_data, [])  # should we set the original origin here?
-                for source_connector in self.source_connectors_by_name.get(None, []):
-                    if source_connector.current_id is not None:
-                        try:
-                            self.source_connectors_by_id[source_connector.current_id].remove(source_connector)
-                        except ValueError:
-                            pass
-                    source_connector.change_id(default_source_data.index)
-                    self.source_connectors_by_id[default_source_data.index].append(source_connector)
-                    source_connector.on_change(default_source_data, [])  # should we set the original origin here?
+                await self.__on_event_server_change(origin)
+
+    async def __on_event_new_sink(self, sink_index: int) -> None:
+        data = await self.pulse.sink_info(sink_index)
+        name = data.name
+        for connector in self.sink_connectors_by_name.get(name, []):
+            connector.change_id(sink_index)
+            self.sink_connectors_by_id[sink_index].append(connector)
+            connector.on_change(data, [])
+
+    async def __on_event_new_source(self, source_index: int) -> None:
+        data = await self.pulse.source_info(source_index)
+        name = data.name
+        for source_connector in self.source_connectors_by_name.get(name, []):
+            source_connector.change_id(source_index)
+            self.source_connectors_by_id[source_index].append(source_connector)
+            source_connector.on_change(data, [])
+
+    async def __on_event_remove_sink(self, sink_index: int) -> None:
+        for connector in self.sink_connectors_by_id.get(sink_index, []):
+            connector.change_id(None)
+        if sink_index in self.sink_connectors_by_id:
+            del self.sink_connectors_by_id[sink_index]
+
+    async def __on_event_remove_source(self, source_index: int) -> None:
+        for source_connector in self.source_connectors_by_id.get(source_index, []):
+            source_connector.change_id(None)
+        if source_index in self.source_connectors_by_id:
+            del self.source_connectors_by_id[source_index]
+
+    async def __on_event_server_change(self, origin: List[Any]) -> None:
+        # For server change events, we need to update our default_*_name connectors and possibly change the
+        # current_id of all the default_sink/source_* connectors (and update them with the current state of the
+        # new default sink/source)
+        server_info = await self.pulse.server_info()
+        self._default_sink_name_connector._update(server_info, origin)
+        self._default_source_name_connector._update(server_info, origin)
+        # Update default sink/source connectors
+        default_sink_data = await self.pulse.get_sink_by_name(server_info.default_sink_name)
+        default_source_data = await self.pulse.get_source_by_name(server_info.default_source_name)
+        for connector in self.sink_connectors_by_name.get(None, []):
+            if connector.current_id is not None:
+                try:
+                    self.sink_connectors_by_id[connector.current_id].remove(connector)
+                except ValueError:
+                    pass
+            connector.change_id(default_sink_data.index)
+            self.sink_connectors_by_id[default_sink_data.index].append(connector)
+            connector.on_change(default_sink_data, [])  # should we set the original origin here?
+        for source_connector in self.source_connectors_by_name.get(None, []):
+            if source_connector.current_id is not None:
+                try:
+                    self.source_connectors_by_id[source_connector.current_id].remove(source_connector)
+                except ValueError:
+                    pass
+            source_connector.change_id(default_source_data.index)
+            self.source_connectors_by_id[default_source_data.index].append(source_connector)
+            source_connector.on_change(default_source_data, [])  # should we set the original origin here?
 
     def _register_origin_callback(self, facility: str, index: int, origin: List[Any]) -> None:
         # Avoid infinite growing of event_origin dict's lists, by adding origins of events that will never be

--- a/shc/interfaces/pulse.py
+++ b/shc/interfaces/pulse.py
@@ -18,11 +18,11 @@ import ctypes as c
 
 if TYPE_CHECKING:
     from pulsectl import (
-        PulseEventInfo, PulseSinkInfo, PulseSourceInfo, PulseServerInfo, PulseVolumeInfo)
+        PulseEventInfo, PulseSinkInfo, PulseSourceInfo, PulseServerInfo)
     from pulsectl_asyncio import PulseAsync
 
 import shc.conversion
-from shc.base import Connectable, Subscribable, Readable, T, UninitializedError, Writable
+from shc.base import Subscribable, Readable, T, UninitializedError, Writable
 from shc.datatypes import RangeFloat1, Balance
 from shc.interfaces._helper import SupervisedClientInterface
 

--- a/shc/interfaces/shc_client.py
+++ b/shc/interfaces/shc_client.py
@@ -20,7 +20,6 @@ import aiohttp
 from ._helper import SupervisedClientInterface
 from ..base import T, Subscribable, Writable, Readable, UninitializedError, Reading
 from ..conversion import SHCJsonEncoder, from_json
-from ..supervisor import register_interface, stop
 
 logger = logging.getLogger(__name__)
 

--- a/shc/interfaces/shc_client.py
+++ b/shc/interfaces/shc_client.py
@@ -141,7 +141,7 @@ class SHCWebClient(SupervisedClientInterface):
 
         try:
             name = message["name"]
-            status = message["status"]
+            _status = message["status"]  # noqa: F841
         except KeyError:
             logger.warning("Websocket message from SHC server does not include 'name' and 'status' fields: %s",
                            msg.data)

--- a/shc/interfaces/tasmota.py
+++ b/shc/interfaces/tasmota.py
@@ -16,7 +16,6 @@ import functools
 import json
 import logging
 import re
-import time
 from typing import List, Any, Dict, Deque, Generic, Union, Type, TypeVar, Tuple, cast, Optional, NamedTuple
 
 from paho.mqtt.client import MQTTMessage

--- a/shc/interfaces/telegram.py
+++ b/shc/interfaces/telegram.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import logging
 import re
-from typing import Generic, TypeVar, Set, Type, Optional, List, Pattern, Tuple, Dict, Any, Callable
+from typing import Generic, TypeVar, Set, Type, Optional, List, Dict, Any, Callable
 
 import aiogram
 from aiogram.bot.api import TelegramAPIServer, TELEGRAM_PRODUCTION

--- a/shc/log/file_persistence.py
+++ b/shc/log/file_persistence.py
@@ -1,8 +1,7 @@
 import asyncio
-import io
 import json
 import logging
-from typing import IO, Any, Dict, Tuple, Optional, Generic, List, Type
+from typing import Any, Dict, Tuple, Optional, Generic, List, Type
 from pathlib import Path
 
 import aiofile

--- a/shc/log/generic.py
+++ b/shc/log/generic.py
@@ -66,7 +66,7 @@ class PersistenceVariable(Readable[T], Writable[T], Generic[T], metaclass=abc.AB
         """
         pass
 
-    async def retrieve_aggregated_log(self, start_time: datetime.datetime, end_time: datetime.datetime,
+    async def retrieve_aggregated_log(self, start_time: datetime.datetime, end_time: datetime.datetime,  # noqa: C901
                                       aggregation_method: AggregationMethod, aggregation_interval: datetime.timedelta
                                       ) -> List[Tuple[datetime.datetime, float]]:
         data = await self.retrieve_log(start_time, end_time, include_previous=True)

--- a/shc/misc.py
+++ b/shc/misc.py
@@ -14,7 +14,7 @@ import logging
 from typing import Generic, Type, List, Any, Optional, Callable, Dict, Awaitable
 
 from shc import conversion
-from shc.base import Readable, Subscribable, Writable, handler, T, ConnectableWrapper, UninitializedError, Reading, S
+from shc.base import Readable, Subscribable, Writable, T, ConnectableWrapper, UninitializedError, Reading, S
 from shc.datatypes import RangeFloat1, FadeStep
 from shc.expressions import ExpressionWrapper
 from shc.timer import Every

--- a/shc/supervisor.py
+++ b/shc/supervisor.py
@@ -10,12 +10,11 @@
 # specific language governing permissions and limitations under the License.
 import abc
 import asyncio
-import collections
 import enum
 import functools
 import logging
 import signal
-from typing import Set, NamedTuple, Dict, Any, Union, Iterable, Deque, Tuple
+from typing import Set, NamedTuple, Iterable
 
 from .base import Readable
 from .timer import timer_supervisor

--- a/shc/timer.py
+++ b/shc/timer.py
@@ -617,7 +617,6 @@ class Delay(Subscribable[T], Readable[T], Generic[T]):
             await _logarithmic_sleep(datetime.datetime.now() + self.delay)
         except asyncio.CancelledError:
             return
-        changed = value != self._value
         logger.debug("Value %s for Delay %s is now active and published", value, self)
         self._value = value
         self._publish(value, origin)

--- a/shc/util/check_shc.py
+++ b/shc/util/check_shc.py
@@ -21,11 +21,10 @@ Only monitoring metrics (ignoring the overall server state):
 import argparse
 import enum
 import json
-import re
 import sys
 import urllib.request
 import urllib.error
-from typing import NamedTuple, Optional, Tuple, NoReturn, List
+from typing import NoReturn
 
 
 def main() -> None:

--- a/shc/variables.py
+++ b/shc/variables.py
@@ -12,7 +12,7 @@
 import asyncio
 import logging
 import warnings
-from typing import Generic, Type, Optional, List, Any, Union, Dict, NamedTuple
+from typing import Generic, Type, Optional, List, Any, Union, Dict
 
 from .base import Writable, T, Readable, Subscribable, UninitializedError, Reading
 from .expressions import ExpressionWrapper

--- a/shc/web/log_widgets.py
+++ b/shc/web/log_widgets.py
@@ -1,8 +1,6 @@
 import datetime
-from pathlib import Path
 from typing import Iterable, Optional, Generic, Union, Callable, NamedTuple, Tuple, List
 
-import jinja2
 from markupsafe import Markup
 
 from ..log.generic import PersistenceVariable, LoggingRawWebUIView, AggregationMethod, LoggingAggregatedWebUIView

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Michael Thies <mail@mhthies.de>
+# Copyright 2020-2022 Michael Thies <mail@mhthies.de>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License. You may obtain a copy of the License at

--- a/test/interfaces/test_knx.py
+++ b/test/interfaces/test_knx.py
@@ -130,10 +130,11 @@ class KNXDConnectorTest(unittest.TestCase):
 
     @async_test
     async def test_respond(self) -> None:
-        group_connector1 = self.interface.group(knx.KNXGAD(1, 2, 3), "1")\
-            .connect(ExampleReadable(bool, True), read=True)
-        group_connector2 = self.interface.group(knx.KNXGAD(17, 5, 127), "10")\
-            .connect(ExampleReadable(knxdclient.KNXTime, knxdclient.KNXTime(datetime.time(6, 0, 11), 5)), read=True)
+        _group_connector1 = self.interface.group(knx.KNXGAD(1, 2, 3), "1")\
+            .connect(ExampleReadable(bool, True), read=True)  # noqa: F841
+        _group_connector2 = self.interface.group(knx.KNXGAD(17, 5, 127), "10")\
+            .connect(ExampleReadable(knxdclient.KNXTime, knxdclient.KNXTime(datetime.time(6, 0, 11), 5)),  # noqa: F841
+                     read=True)
 
         self.interface_runner.start()
 

--- a/test/interfaces/test_midi.py
+++ b/test/interfaces/test_midi.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 import unittest
 import unittest.mock
@@ -7,7 +6,7 @@ import mido
 import shc.interfaces.midi
 from shc.datatypes import RangeUInt8
 
-from .._helper import InterfaceThreadRunner, AsyncMock
+from .._helper import InterfaceThreadRunner
 
 
 try:

--- a/test/interfaces/test_shc_client.py
+++ b/test/interfaces/test_shc_client.py
@@ -157,8 +157,8 @@ class SHCWebsocketClientTest(unittest.TestCase):
         client_bar = self.client.object(ExampleType, 'bar')
         bar_target = ExampleWritable(ExampleType)\
             .connect(client_bar)
-        client_foo = self.client.object(int, 'foo')\
-            .connect(ExampleReadable(int, 56), read=True)
+        _client_foo = self.client.object(int, 'foo')\
+            .connect(ExampleReadable(int, 56), read=True)  # noqa: F841
         client_status_target = ExampleWritable(shc.supervisor.InterfaceStatus)\
             .connect(self.client.monitoring_connector())
 

--- a/test/interfaces/test_shc_client.py
+++ b/test/interfaces/test_shc_client.py
@@ -9,7 +9,6 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 import asyncio
-import datetime
 import logging
 import unittest
 import unittest.mock
@@ -21,7 +20,7 @@ import aiohttp
 import shc.web
 import shc.interfaces.shc_client
 from test._helper import ExampleReadable, InterfaceThreadRunner, ExampleWritable, ExampleSubscribable, async_test, \
-    ClockMock, AsyncMock
+    AsyncMock
 
 
 class ExampleType(NamedTuple):

--- a/test/interfaces/test_tasmota.py
+++ b/test/interfaces/test_tasmota.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import json
 import shutil
 import subprocess

--- a/test/interfaces/test_tasmota.py
+++ b/test/interfaces/test_tasmota.py
@@ -158,7 +158,7 @@ class TasmotaInterfaceTest(unittest.TestCase):
             target_power._write.assert_called_once_with(False, unittest.mock.ANY)
 
             async with asyncio_mqtt.Client("localhost", 42883, client_id="some-other-client") as c:
-                await c.publish(f"cmnd/test-device/color", b'#aabbcc', retain=True)
+                await c.publish("cmnd/test-device/color", b'#aabbcc', retain=True)
 
             await asyncio.sleep(0.1)
             target_color._write.assert_called_with(construct_color(170, 187, 204, 0), [conn_color])  # rounding error
@@ -220,7 +220,7 @@ class TasmotaInterfaceTest(unittest.TestCase):
         target_ir._write.assert_not_called()
 
         async with asyncio_mqtt.Client("localhost", 42883, client_id="some-other-client") as c:
-            await c.publish(f"tele/test-device/RESULT",
+            await c.publish("tele/test-device/RESULT",
                             json.dumps({"Time": "1970-01-10T03:12:43",
                                         "IrReceived": {"Protocol": "NEC", "Bits": 32, "Data": "0x00F7609F"}})
                             .encode('ascii'))
@@ -258,7 +258,7 @@ class TasmotaInterfaceTest(unittest.TestCase):
         target_total._write.assert_not_called()
 
         async with asyncio_mqtt.Client("localhost", 42883, client_id="some-other-client") as c:
-            await c.publish(f"tele/test-device/SENSOR",
+            await c.publish("tele/test-device/SENSOR",
                             json.dumps({"Time": "1970-01-01T00:49:50",
                                         "ENERGY": {"TotalStartTime": "1970-01-01T00:00:00", "Total": 0.012,
                                                    "Yesterday": 0.000, "Today": 0.012, "Period": 2, "Power": 15,

--- a/test/interfaces/test_telegram.py
+++ b/test/interfaces/test_telegram.py
@@ -72,8 +72,8 @@ class TelegramBotTest(unittest.TestCase):
     @async_test
     async def test_write(self) -> None:
         foo = self.client.on_off_connector("Foo", {'max', 'tim'})
-        foo_target = ExampleWritable(bool)\
-            .connect(foo)
+        _foo_target = ExampleWritable(bool)\
+            .connect(foo)  # noqa: F841
         foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {'max', 'alice'})
         foobar_target = ExampleWritable(int)\
             .connect(foobar)
@@ -171,11 +171,11 @@ class TelegramBotTest(unittest.TestCase):
 
     @async_test
     async def test_inline_cancel(self) -> None:
-        foo = self.client.on_off_connector("Foo", {'max', 'tim'})\
-            .connect(ExampleReadable(bool, False))
-        foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {'max', 'alice'})\
+        _foo = self.client.on_off_connector("Foo", {'max', 'tim'})\
+            .connect(ExampleReadable(bool, False))  # noqa: F841
+        _foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {'max', 'alice'})\
             .connect(ExampleReadable(int, 42))\
-            .connect(ExampleWritable(int))
+            .connect(ExampleWritable(int))  # noqa: F841
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -230,7 +230,7 @@ class TelegramBotTest(unittest.TestCase):
 
     @async_test
     async def test_auth_errors(self) -> None:
-        foo = self.client.on_off_connector("Foo", {'max', 'tim'})
+        _foo = self.client.on_off_connector("Foo", {'max', 'tim'})  # noqa: F841
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -322,15 +322,16 @@ class TelegramBotTest(unittest.TestCase):
 
     @async_test
     async def test_read(self) -> None:
-        foo = self.client.str_connector("Foo", {'max'}, {'max', 'tim'})\
+        _foo = self.client.str_connector("Foo", {'max'}, {'max', 'tim'})\
             .connect(ExampleWritable(str))\
-            .connect(ExampleReadable(str, "hello, world!"))
-        foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {'max', 'alice'},
-                                               options=["0", "5", "15"])\
+            .connect(ExampleReadable(str, "hello, world!"))  # noqa: F841
+        _foobar = self.client.generic_connector(int, "Foobar",  # noqa: F841
+                                                lambda x: str(x), lambda x: int(x), {'max', 'alice'},
+                                                options=["0", "5", "15"])\
             .connect(ExampleWritable(int))\
-            .connect(ExampleReadable(int, 42))
-        bar = self.client.generic_connector(str, "Bar", lambda x: x, lambda x: x, {'alice', 'max'}, {'alice'})\
-            .connect(ExampleWritable(str))
+            .connect(ExampleReadable(int, 42))  # noqa: F841
+        _bar = self.client.generic_connector(str, "Bar", lambda x: x, lambda x: x, {'alice', 'max'}, {'alice'})\
+            .connect(ExampleWritable(str))  # noqa: F841
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -543,7 +544,7 @@ class TelegramAPIMock:
 
     def _create_send_message_response(self, data: Dict[str, JSON_TYPE]) -> Dict[str, JSON_TYPE]:
         if 'text' not in data:
-            raise aiohttp.web.HTTPNotImplemented(text=f"Only text messages are implemented in the Mock")
+            raise aiohttp.web.HTTPNotImplemented(text="Only text messages are implemented in the Mock")
         return {
             'message_id': random.randint(0, 2**32),
             'from': self.user_object,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -13,41 +13,41 @@ async def shutdown() -> None:
 class BasicTest(unittest.TestCase):
     def test_ui_showcase(self) -> None:
         shc.supervisor.event_loop.create_task(shutdown())
-        import example.ui_showcase  # type: ignore
+        import example.ui_showcase  # type: ignore  # noqa: F401
         shc.main()
 
     def test_ui_logging_showcase(self) -> None:
         shc.supervisor.event_loop.create_task(shutdown())
 
-        import example.ui_logging_showcase  # type: ignore
+        import example.ui_logging_showcase  # type: ignore  # noqa: F401
         shc.main()
 
     def test_server_client_example(self) -> None:
         shc.supervisor.event_loop.create_task(shutdown())
 
         # The examples should actually be able to coexist in a single SHC instance
-        import example.server_client.server  # type: ignore
-        import example.server_client.client  # type: ignore
+        import example.server_client.server  # type: ignore  # noqa: F401
+        import example.server_client.client  # type: ignore  # noqa: F401
         shc.main()
 
     def test_tasmota_led_example(self) -> None:
-        import example.tasmota_led_ir_with_ui  # type: ignore
+        import example.tasmota_led_ir_with_ui  # type: ignore  # noqa: F401
 
     def test_telegram_example(self) -> None:
-        import example.telegram  # type: ignore
+        import example.telegram  # type: ignore  # noqa: F401
 
     def test_pulseaudio_sink_example(self) -> None:
-        import example.pulseaudio_sink  # type: ignore
+        import example.pulseaudio_sink  # type: ignore  # noqa: F401
 
     def test_knx_specifics_example(self) -> None:
-        import example.knx_specifics  # type: ignore
+        import example.knx_specifics  # type: ignore  # noqa: F401
 
     def test_custom_ui_widet_example(self) -> None:
-        import example.custom_ui_widget.main  # type: ignore
+        import example.custom_ui_widget.main  # type: ignore  # noqa: F401
         # TODO add selenium test for actual position of the indicator
 
     def test_sun_position_weather_forecast_example(self) -> None:
-        import example.sun_position_weather_forecast  # type: ignore
+        import example.sun_position_weather_forecast  # type: ignore  # noqa: F401
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/test/test_interfaces_stub.py
+++ b/test/test_interfaces_stub.py
@@ -3,10 +3,10 @@ import unittest
 
 class InterfaceImportTest(unittest.TestCase):
     def test_knx(self):
-        import shc.interfaces.knx
+        import shc.interfaces.knx  # noqa: F401
 
     def test_dmx(self):
-        import shc.interfaces.dmx
+        import shc.interfaces.dmx  # noqa: F401
 
     def test_midi(self):
-        import shc.interfaces.midi
+        import shc.interfaces.midi  # noqa: F401

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -215,7 +215,7 @@ class ConnectedExchangeVariableTest(unittest.TestCase):
         var2 = shc.Variable(int)
         _exchange = shc.misc.UpdateExchange(int) \
             .connect(var1)\
-            .connect(var2)
+            .connect(var2)  # noqa: F841
 
         await asyncio.gather(var1.write(42, []), var2.write(56, []))
         await asyncio.sleep(0.1)

--- a/test/test_timer.py
+++ b/test/test_timer.py
@@ -6,8 +6,8 @@ from unittest.mock import Mock
 from typing import Optional, List
 
 import shc.base
-from shc import timer, base, datatypes
-from ._helper import ClockMock, async_test, ExampleSubscribable, AsyncMock, ExampleWritable, ExampleReadable
+from shc import timer, datatypes
+from ._helper import ClockMock, async_test, ExampleSubscribable, ExampleWritable, ExampleReadable
 
 
 class LogarithmicSleepTest(unittest.TestCase):

--- a/test/test_timer.py
+++ b/test/test_timer.py
@@ -208,7 +208,7 @@ class AtTimerTest(unittest.TestCase):
         self.assertAlmostEqual(expected.astimezone(), actual, delta=datetime.timedelta(seconds=.1))
 
     def test_simple_next(self) -> None:
-        with ClockMock(datetime.datetime(2020, 1, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2020, 1, 1, 15, 7, 17)):
             once_timer = timer.At(hour=15, minute=7, second=17, millis=200)
             self._assert_datetime(datetime.datetime(2020, 1, 1, 15, 7, 17, 200000), once_timer._next_execution())
             once_timer = timer.At(hour=15, minute=7, second=25)
@@ -229,7 +229,7 @@ class AtTimerTest(unittest.TestCase):
             self._assert_datetime(datetime.datetime(2020, 4, 6, 0, 0, 0), once_timer._next_execution())
 
     def test_spec_forms(self) -> None:
-        with ClockMock(datetime.datetime(2020, 1, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2020, 1, 1, 15, 7, 17)):
             once_timer = timer.At(hour=timer.EveryNth(2))
             self._assert_datetime(datetime.datetime(2020, 1, 1, 16, 0, 0), once_timer._next_execution())
             once_timer = timer.At(hour=timer.EveryNth(6))
@@ -242,7 +242,7 @@ class AtTimerTest(unittest.TestCase):
             self._assert_datetime(datetime.datetime(2020, 1, 1, 15, 7, 17), once_timer._next_execution())
 
     def test_stepback(self) -> None:
-        with ClockMock(datetime.datetime(2020, 1, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2020, 1, 1, 15, 7, 17)):
             once_timer = timer.At(hour=None, minute=0)
             self._assert_datetime(datetime.datetime(2020, 1, 1, 16, 0, 0), once_timer._next_execution())
             once_timer = timer.At(hour=15, minute=0)
@@ -251,28 +251,28 @@ class AtTimerTest(unittest.TestCase):
             self._assert_datetime(datetime.datetime(2021, 1, 1, 0, 5, 16), once_timer._next_execution())
 
     def test_overflows(self) -> None:
-        with ClockMock(datetime.datetime(2020, 12, 31, 23, 59, 46)) as clock:
+        with ClockMock(datetime.datetime(2020, 12, 31, 23, 59, 46)):
             once_timer = timer.At(hour=None, minute=None, second=timer.EveryNth(15))
             self._assert_datetime(datetime.datetime(2021, 1, 1, 0, 0, 0), once_timer._next_execution())
-        with ClockMock(datetime.datetime(2019, 2, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2019, 2, 1, 15, 7, 17)):
             once_timer = timer.At(day=29)
             self._assert_datetime(datetime.datetime(2019, 3, 29, 0, 0, 0), once_timer._next_execution())
-        with ClockMock(datetime.datetime(2020, 2, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2020, 2, 1, 15, 7, 17)):
             once_timer = timer.At(day=29)
             self._assert_datetime(datetime.datetime(2020, 2, 29, 0, 0, 0), once_timer._next_execution())
-        with ClockMock(datetime.datetime(2020, 4, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2020, 4, 1, 15, 7, 17)):
             once_timer = timer.At(day=31)
             self._assert_datetime(datetime.datetime(2020, 5, 31, 0, 0, 0), once_timer._next_execution())
-        with ClockMock(datetime.datetime(2019, 1, 1, 15, 7, 17)) as clock:
+        with ClockMock(datetime.datetime(2019, 1, 1, 15, 7, 17)):
             once_timer = timer.At(weeknum=53)
             self._assert_datetime(datetime.datetime(2020, 12, 28, 0, 0, 0), once_timer._next_execution())
-        with ClockMock(datetime.datetime(2020, 1, 1, 0, 0, 0)) as clock:
+        with ClockMock(datetime.datetime(2020, 1, 1, 0, 0, 0)):
             once_timer = timer.At(year=2019)
             self.assertIsNone(once_timer._next_execution())
 
     def test_exception(self) -> None:
         with self.assertRaises(ValueError):
-            once_timer = timer.At(day=[1, 5, 15], weeknum=timer.EveryNth(2))
+            timer.At(day=[1, 5, 15], weeknum=timer.EveryNth(2))
 
 
 class BoolTimerTest(unittest.TestCase):
@@ -288,7 +288,7 @@ class BoolTimerTest(unittest.TestCase):
         ton = timer.TOn(base, datetime.timedelta(seconds=42))
 
         with unittest.mock.patch.object(ton, "_publish", new=Mock(side_effect=save_time)) as publish_mock:
-            with ClockMock(begin, actual_sleep=0.05) as clock:
+            with ClockMock(begin, actual_sleep=0.05):
                 self.assertFalse(await ton.read())
 
                 # False should not be forwarded, when value is already False
@@ -340,7 +340,7 @@ class BoolTimerTest(unittest.TestCase):
         toff = timer.TOff(base, datetime.timedelta(seconds=42))
 
         with unittest.mock.patch.object(toff, "_publish", new=Mock(side_effect=save_time)) as publish_mock:
-            with ClockMock(begin, actual_sleep=0.05) as clock:
+            with ClockMock(begin, actual_sleep=0.05):
                 self.assertFalse(await toff.read())
 
                 # False should not be forwarded, when value is already False
@@ -498,7 +498,7 @@ class TimerSwitchTest(unittest.TestCase):
         timerswitch = timer.TimerSwitch([pub_on1, pub_on2], duration=datetime.timedelta(seconds=42))
 
         with unittest.mock.patch.object(timerswitch, "_publish") as publish_mock:
-            with ClockMock(begin, actual_sleep=0.05) as clock:
+            with ClockMock(begin, actual_sleep=0.05):
                 self.assertFalse(await timerswitch.read())
 
                 await pub_on2.publish(None, [self])
@@ -550,7 +550,7 @@ class RateLimitedSubscriptionTest(unittest.TestCase):
         self.assertIs(rate_limiter.type, int)
 
         with unittest.mock.patch.object(rate_limiter, "_publish", new=Mock(side_effect=save_time)) as publish_mock:
-            with ClockMock(begin, actual_sleep=0.05) as clock:
+            with ClockMock(begin, actual_sleep=0.05):
                 # First value should be forwarded immediately
                 await base.publish(42, [self])
                 await asyncio.sleep(0.1)
@@ -609,7 +609,7 @@ class RampTest(unittest.TestCase):
         with self.assertRaises(shc.base.UninitializedError):
             await ramp2.read()
 
-        with ClockMock(begin, actual_sleep=0.05) as clock:
+        with ClockMock(begin, actual_sleep=0.05):
             await subscribable1.publish(datatypes.RangeUInt8(0), [self])
             await subscribable2.publish(datatypes.RangeFloat1(0), [self])
             await subscribable3.publish(BLACK, [self])
@@ -680,7 +680,7 @@ class RampTest(unittest.TestCase):
         ramp1 = timer.RGBHSVRamp(subscribable1, datetime.timedelta(seconds=1), max_frequency=2, enable_ramp=enable1)
         writable1 = ExampleWritable(datatypes.RGBUInt8).connect(ramp1)
 
-        with ClockMock(begin, actual_sleep=0.05) as clock:
+        with ClockMock(begin, actual_sleep=0.05):
             # Ramping should work normal (as in the other test
             await subscribable1.publish(BLACK, [self])
             writable1._write.assert_called_once_with(BLACK, [self, subscribable1, ramp1])
@@ -722,7 +722,7 @@ class RampTest(unittest.TestCase):
         variable1 = shc.Variable(datatypes.RangeUInt8).connect(ramp1)
         writable1 = ExampleWritable(datatypes.RangeUInt8).connect(variable1)
 
-        with ClockMock(begin, actual_sleep=0.05) as clock:
+        with ClockMock(begin, actual_sleep=0.05):
             await subscribable1.publish(datatypes.RangeUInt8(0), [self])
             await asyncio.sleep(0.05)
             writable1._write.assert_called_once_with(datatypes.RangeUInt8(0), [self, subscribable1, ramp1, variable1])
@@ -759,7 +759,7 @@ class RampTest(unittest.TestCase):
         variable1 = shc.Variable(datatypes.RangeFloat1).connect(ramp1)
         writable1 = ExampleWritable(datatypes.RangeFloat1).connect(variable1)
 
-        with ClockMock(begin, actual_sleep=0.05) as clock:
+        with ClockMock(begin, actual_sleep=0.05):
             with self.assertLogs() as logs:
                 await subscribable1.publish(datatypes.FadeStep(0.5), [self])
                 await asyncio.sleep(0.05)

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 import mypy.api
 
 from shc import variables, base, expressions
-from ._helper import async_test, ExampleReadable, ExampleWritable, AsyncMock
+from ._helper import async_test, ExampleReadable, ExampleWritable
 
 
 class SimpleVariableTest(unittest.TestCase):

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -180,9 +180,9 @@ class VariableFieldsTest(unittest.TestCase):
 
         with warnings.catch_warnings(record=True):  # There seems to be a bug, that record=False breaks the catching
             with self.assertRaises(AttributeError):
-                var_c = var.c
+                _var_c = var.c  # noqa: F841
             with self.assertRaises(AttributeError):
-                var_c = var.a.c
+                _var_c = var.a.c  # noqa: F841
 
             with self.assertRaises(base.UninitializedError):
                 await var.a.a.write(21, [self])

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -630,7 +630,7 @@ class TestAPI(unittest.TestCase):
         self.server_runner.stop()
 
     def test_rest_get(self) -> None:
-        api_object = self.server.api(int, "the_api_object").connect(ExampleReadable(int, 42))
+        _api_object = self.server.api(int, "the_api_object").connect(ExampleReadable(int, 42))  # noqa: F841
         self.server_runner.start()
 
         with self.assertRaises(urllib.error.HTTPError) as cm:
@@ -819,7 +819,7 @@ class WebSocketAPITest(unittest.TestCase):
 
     @async_test
     async def test_errors(self) -> None:
-        api_object = self.server.api(int, "the_api_object").connect(ExampleReadable(int, 42))
+        _api_object = self.server.api(int, "the_api_object").connect(ExampleReadable(int, 42))  # noqa: F841
         self.server_runner.start()
         await self.start_websocket()
 
@@ -869,7 +869,7 @@ class WebSocketAPITest(unittest.TestCase):
 
     @async_test
     async def test_get(self) -> None:
-        api_object = self.server.api(int, "the_api_object").connect(ExampleReadable(int, 42))
+        _api_object = self.server.api(int, "the_api_object").connect(ExampleReadable(int, 42))  # noqa: F841
         self.server_runner.start()
         await self.start_websocket()
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -24,8 +24,8 @@ import shc.web
 import shc.web.widgets
 from shc.datatypes import RangeFloat1, RGBUInt8, RangeUInt8
 from shc.interfaces._helper import ReadableStatusInterface
-from shc.supervisor import AbstractInterface, InterfaceStatus, ServiceStatus
-from ._helper import InterfaceThreadRunner, ExampleReadable, AsyncMock, async_test
+from shc.supervisor import InterfaceStatus, ServiceStatus
+from ._helper import InterfaceThreadRunner, ExampleReadable, async_test
 
 
 class StatusTestInterface(ReadableStatusInterface):


### PR DESCRIPTION
- Use flake8 in the GitHub Actions CI
- Add instructions to the readme file

Fixed codestyle issues:
- Many unused imports
- Some unused variables (some of them are okay) and unnecessary f-strings
- High complexity of method `shc.interfaces._helper.SupervisedClientInterface.supervise()`
- High complexity of method `shc.web.interface.WebServer._api_websocket_dispatch()`
- High complexity of method `shc.interfaces.pulse.PulseAudioInterface._dispatch_pulse_event()`

Not yet fixed:
- High complexity of method `shc.log.generic.PersistenceVariable.retrieve_aggregated_log()` – this Code is currently being reworked, so it does not make sense to fix it at its current position.