### PR TITLE
add list of list support to buttongroup widget

### DIFF
--- a/example/pulseaudio_sink.py
+++ b/example/pulseaudio_sink.py
@@ -13,11 +13,12 @@
 A simple SHC example, providing a web interface to control and supervise the default sink of the local Pulseaudio
 server.
 """
+from typing import cast, Iterable
 
 import shc
 import shc.web
 import shc.interfaces.pulse
-from shc.web.widgets import Slider, ButtonGroup, ToggleButton, icon, DisplayButton
+from shc.web.widgets import AbstractButton, Slider, ButtonGroup, ToggleButton, icon, DisplayButton
 
 interface = shc.interfaces.pulse.PulseAudioInterface()
 sink_name = None
@@ -35,10 +36,10 @@ page = web_interface.page('index', "Home")
 page.add_item(Slider("Volume").connect(volume.field('volume')))
 page.add_item(Slider("Balance").connect(volume.field('balance'), convert=True))
 page.add_item(Slider("Fade").connect(volume.field('fade'), convert=True))
-page.add_item(ButtonGroup("", [
+page.add_item(ButtonGroup("", cast(Iterable[AbstractButton], [
     ToggleButton(icon('volume mute')).connect(mute),
     DisplayButton(label=icon('power off')).connect(active),
-]))
+])))
 
 if __name__ == '__main__':
     shc.main()

--- a/example/ui_showcase.py
+++ b/example/ui_showcase.py
@@ -65,7 +65,7 @@ index_page.add_item(ButtonGroup("State of the foobar", [
 
 # A simple ButtonGroup with nested lists of ToggleButtons for foobar
 index_page.add_item(ButtonGroup("State of the foobar (grouped)", [
-    [ToggleButton("Foo").connect(foo),ToggleButton("Bar", color='red').connect(bar)],
+    [ToggleButton("Foo").connect(foo), ToggleButton("Bar", color='red').connect(bar)],
     [ToggleButton("Foobar", color='black').connect(foobar)],
 ]))
 

--- a/example/ui_showcase.py
+++ b/example/ui_showcase.py
@@ -63,6 +63,12 @@ index_page.add_item(ButtonGroup("State of the foobar", [
                  confirm_message="Do you want the foobar?", confirm_values=[True]).connect(foobar),
 ]))
 
+# A simple ButtonGroup with nested lists of ToggleButtons for foobar
+index_page.add_item(ButtonGroup("State of the foobar (grouped)", [
+    [ToggleButton("Foo").connect(foo),ToggleButton("Bar", color='red').connect(bar)],
+    [ToggleButton("Foobar", color='black').connect(foobar)],
+]))
+
 # We can also use ValueButtons to represent individual states (here in the 'outline' version)
 index_page.add_item(ButtonGroup("The Foo", [
     ValueButton(False, "Off", outline=True, color="black").connect(foo),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "smarthomeconnect",
+  "name": "shc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "shc2",
+  "name": "smarthomeconnect",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/shc/web/templates/widgets/buttongroup.htm
+++ b/shc/web/templates/widgets/buttongroup.htm
@@ -1,7 +1,13 @@
 {% from "buttons.inc.htm" import render_button %}
 <label class="shc label float-btn">{{ label }}</label>
-<div class="ui buttons right floated">
-    {% for button in buttons %}
-        {{ render_button(button) }}
+<div class="ui spaced horizontal list right floated">
+    {% for button_group in button_groups %}
+    <div class="item">
+        <div class="ui buttons">
+            {% for button in button_group %}
+                {{ render_button(button) }}
+            {% endfor %}
+        </div>
+    </div>
     {% endfor %}
 </div>

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -324,7 +324,11 @@ class ButtonGroup(WebPageItem):
     :param label: The label to be shown left of the buttons
     :param buttons: List or a List if List of button descriptors
     """
-    def __init__(self, label: Union[str, Markup], buttons: Union[Iterable["AbstractButton"], Iterable[Iterable["AbstractButton"]]]):
+    def __init__(
+        self,
+        label: Union[str, Markup],
+        buttons: Union[Iterable["AbstractButton"], Iterable[Iterable["AbstractButton"]]],
+    ):
         super().__init__()
         self.label = label
         if all(isinstance(item, Iterable) for item in buttons):

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -30,7 +30,19 @@ import itertools
 import json
 import pathlib
 from os import PathLike
-from typing import Any, Type, Union, Iterable, List, Generic, Tuple, TypeVar, Optional, Callable
+from typing import (
+    Any,
+    cast,
+    Type,
+    Union,
+    Iterable,
+    List,
+    Generic,
+    Tuple,
+    TypeVar,
+    Optional,
+    Callable,
+)
 
 import markupsafe
 from markupsafe import Markup
@@ -332,11 +344,11 @@ class ButtonGroup(WebPageItem):
         super().__init__()
         self.label = label
         if all(isinstance(item, Iterable) for item in buttons):
-            self.buttons = list(itertools.chain(*buttons))
-            self.button_groups = buttons
+            self.buttons: Iterable["AbstractButton"] = list(itertools.chain(*buttons))
+            self.button_groups = cast(Iterable[Iterable["AbstractButton"]], buttons)
         else:
-            self.buttons = buttons
-            self.button_groups = [buttons]
+            self.buttons = cast(Iterable["AbstractButton"], buttons)
+            self.button_groups = cast(Iterable[Iterable["AbstractButton"]], [buttons])
 
     def get_connectors(self) -> Iterable[WebUIConnector]:
         return self.buttons  # type: ignore

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -322,19 +322,24 @@ class ButtonGroup(WebPageItem):
     `Connectable`.
 
     :param label: The label to be shown left of the buttons
-    :param buttons: List of button descriptors
+    :param buttons: List or a List if List of button descriptors
     """
-    def __init__(self, label: Union[str, Markup], buttons: Iterable["AbstractButton"]):
+    def __init__(self, label: Union[str, Markup], buttons: Union[Iterable["AbstractButton"], Iterable[Iterable["AbstractButton"]]]):
         super().__init__()
         self.label = label
-        self.buttons = buttons
+        if all(isinstance(item, Iterable) for item in buttons):
+            self.buttons = list(itertools.chain(*buttons))
+            self.button_groups = buttons
+        else:
+            self.buttons = buttons
+            self.button_groups = [buttons]
 
     def get_connectors(self) -> Iterable[WebUIConnector]:
         return self.buttons  # type: ignore
 
     async def render(self) -> str:
         return await jinja_env.get_template('widgets/buttongroup.htm')\
-            .render_async(label=self.label, buttons=self.buttons)
+            .render_async(label=self.label, button_groups=self.button_groups)
 
 
 class AbstractButton(metaclass=abc.ABCMeta):

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -334,7 +334,9 @@ class ButtonGroup(WebPageItem):
     `Connectable`.
 
     :param label: The label to be shown left of the buttons
-    :param buttons: List or a List if List of button descriptors
+    :param buttons: List or a List of Lists of button descriptors.  A plain list of button descriptors will be
+        grouped all together, whereas providing multiple lists each list will be grouped together with a small gap
+        between each group of button descriptors.
     """
     def __init__(
         self,

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -101,6 +101,27 @@ class SimpleWebTest(AbstractWebTest):
         button = self.driver.find_element(By.XPATH, '//button[normalize-space(text()) = "Bar"]')
         self.assertIn("Another button group", button.find_element(By.XPATH, '../../../..').text)
 
+    def test_buttongroup_groups(self) -> None:
+        page = self.server.page('index', 'Home Page')
+        page.add_item(shc.web.widgets.ButtonGroup("My button group", [
+            [shc.web.widgets.StatelessButton(13, "Foo"),
+            shc.web.widgets.StatelessButton(27, "Bar")],
+            [shc.web.widgets.StatelessButton(142, "Gaga")],
+        ]))
+
+        self.server_runner.start()
+        self.driver.get("http://localhost:42080")
+
+        # buttons in 1st group exist and are grouped
+        button = self.driver.find_element(By.XPATH, '//button[normalize-space(text()) = "Foo"]')
+        self.assertEqual("Foo\nBar", button.find_element(By.XPATH, '..').text)
+        button = self.driver.find_element(By.XPATH, '//button[normalize-space(text()) = "Bar"]')
+        self.assertEqual("Foo\nBar", button.find_element(By.XPATH, '..').text)
+
+        # button gaga in 2nd group exist and is the only member in the group
+        button = self.driver.find_element(By.XPATH, '//button[normalize-space(text()) = "Gaga"]')
+        self.assertEqual("Gaga", button.find_element(By.XPATH, '..').text)
+
     def test_main_menu(self) -> None:
         self.server.page('index', menu_entry="Home", menu_icon='home')
         self.server.add_menu_entry('another_page', label="Foo", sub_label="Bar", sub_icon="bars")

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -13,6 +13,7 @@ import urllib.request
 import urllib.error
 import http.client
 from pathlib import Path
+from typing import cast, Iterable
 
 import aiohttp
 from selenium import webdriver
@@ -28,6 +29,7 @@ import shc.web.widgets
 from shc.datatypes import RangeFloat1, RGBUInt8, RangeUInt8
 from shc.interfaces._helper import ReadableStatusInterface
 from shc.supervisor import InterfaceStatus, ServiceStatus
+from shc.web.widgets import AbstractButton
 from ._helper import InterfaceThreadRunner, ExampleReadable, async_test
 
 
@@ -95,9 +97,9 @@ class SimpleWebTest(AbstractWebTest):
         self.assertIn('Home Page', self.driver.title)
         self.assertIn('Another segment', self.driver.page_source)
         button = self.driver.find_element(By.XPATH, '//button[normalize-space(text()) = "Foobar"]')
-        self.assertIn("My button group", button.find_element(By.XPATH, '../..').text)
+        self.assertIn("My button group", button.find_element(By.XPATH, '../../../..').text)
         button = self.driver.find_element(By.XPATH, '//button[normalize-space(text()) = "Bar"]')
-        self.assertIn("Another button group", button.find_element(By.XPATH, '../..').text)
+        self.assertIn("Another button group", button.find_element(By.XPATH, '../../../..').text)
 
     def test_main_menu(self) -> None:
         self.server.page('index', menu_entry="Home", menu_icon='home')
@@ -286,7 +288,9 @@ class WebWidgetsTest(AbstractWebTest):
         ExampleReadable(int, 42).connect(b4)
 
         page = self.server.page('index')
-        page.add_item(shc.web.widgets.ButtonGroup("My button group", [b1, b2, b3, b4]))
+        page.add_item(
+            shc.web.widgets.ButtonGroup("My button group", cast(Iterable[AbstractButton], [b1, b2, b3, b4]))
+        )
 
         with unittest.mock.patch.object(b1, '_publish') as b1_publish, \
                 unittest.mock.patch.object(b3, '_publish') as b3_publish, \

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -105,7 +105,7 @@ class SimpleWebTest(AbstractWebTest):
         page = self.server.page('index', 'Home Page')
         page.add_item(shc.web.widgets.ButtonGroup("My button group", [
             [shc.web.widgets.StatelessButton(13, "Foo"),
-            shc.web.widgets.StatelessButton(27, "Bar")],
+             shc.web.widgets.StatelessButton(27, "Bar")],
             [shc.web.widgets.StatelessButton(142, "Gaga")],
         ]))
 


### PR DESCRIPTION
You can now add list of buttons to the BouttonGroup widget.  These will be displayed in a grouped style.  Added a simple example to `ui_showcase.py`:
```python
# A simple ButtonGroup with nested lists of ToggleButtons for foobar
index_page.add_item(ButtonGroup("State of the foobar (grouped)", [
    [ToggleButton("Foo").connect(foo),ToggleButton("Bar", color='red').connect(bar)],
    [ToggleButton("Foobar", color='black').connect(foobar)],
]))
```

<img width="428" alt="image" src="https://github.com/user-attachments/assets/56196f6b-445b-4285-93fd-5991a1bd87b4">

 