### PR TITLE
Fix selenium webdriver on WSL

### DIFF
--- a/test/test_web.py
+++ b/test/test_web.py
@@ -67,7 +67,6 @@ class AbstractWebTest(unittest.TestCase):
         self.server_runner = InterfaceThreadRunner(shc.web.WebServer, "localhost", 42080, 'index')
         self.server = self.server_runner.interface
 
-
     @classmethod
     def setUpClass(cls) -> None:
         if cls.share_selenium_web_driver():
@@ -102,6 +101,7 @@ class AbstractWebTest(unittest.TestCase):
             return False
 
         return True
+
 
 class SimpleWebTest(AbstractWebTest):
     def test_basic(self) -> None:

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -91,7 +91,7 @@ class AbstractWebTest(unittest.TestCase):
         """Should the selenium driver be shared or not.
 
         Checks whether the environment variable SHARE_SELENIUM_WEB_DRIVER is set.
-        On WSL default ist not sharing the driver since this causes concirrency conflicts.
+        On WSL default ist not sharing the driver since this causes concurrency conflicts.
         """
         if (value := os.getenv('SHARE_SELENIUM_WEB_DRIVER')) is not None:
             return value.strip().lower() in ['1', 'true', 'yes', 'on']

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -53,8 +53,7 @@ class StatusTestInterface(ReadableStatusInterface):
         return f"StatusTestInterface({self.name})"
 
 
-@unittest.skipIf(shutil.which("geckodriver") is None,
-                 "Selenium's geckodriver is not available in PATH")
+@unittest.skipIf(shutil.which("geckodriver") is None, "Selenium's geckodriver is not available in PATH")
 class AbstractWebTest(unittest.TestCase):
     driver: webdriver.Firefox
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -58,7 +58,7 @@ class AbstractWebTest(unittest.TestCase):
     driver: webdriver.Firefox
 
     def setUp(self) -> None:
-        if not self.share_selenium_web_driver():
+        if not self.resue_selenium_web_driver():
             opts = selenium.webdriver.firefox.options.Options()
             opts.add_argument("-headless")
             self.driver = webdriver.Firefox(options=opts)
@@ -68,13 +68,13 @@ class AbstractWebTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        if cls.share_selenium_web_driver():
+        if cls.resue_selenium_web_driver():
             opts = selenium.webdriver.firefox.options.Options()
             opts.add_argument("-headless")
             cls.driver = webdriver.Firefox(options=opts)
 
     def tearDown(self) -> None:
-        if not self.share_selenium_web_driver():
+        if not self.resue_selenium_web_driver():
             self.driver.close()
             self.driver.quit()
 
@@ -82,18 +82,18 @@ class AbstractWebTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        if cls.share_selenium_web_driver():
+        if cls.resue_selenium_web_driver():
             cls.driver.close()
             cls.driver.quit()
 
     @staticmethod
-    def share_selenium_web_driver() -> bool:
-        """Should the selenium driver be shared or not.
+    def resue_selenium_web_driver() -> bool:
+        """Determine whether the selenium driver shall be shared between all consecutive tests in this class.
 
-        Checks whether the environment variable SHARE_SELENIUM_WEB_DRIVER is set.
+        Checks whether the environment variable SHC_TEST_REUSE_WEB_DRIVER is set.
         On WSL default ist not sharing the driver since this causes concurrency conflicts.
         """
-        if (value := os.getenv('SHARE_SELENIUM_WEB_DRIVER')) is not None:
+        if (value := os.getenv('SHC_TEST_REUSE_WEB_DRIVER')) is not None:
             return value.strip().lower() in ['1', 'true', 'yes', 'on']
 
         if "WSL_DISTRO_NAME" in os.environ or "WSL_INTEROP" in os.environ:

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -58,7 +58,7 @@ class AbstractWebTest(unittest.TestCase):
     driver: webdriver.Firefox
 
     def setUp(self) -> None:
-        if not self.resue_selenium_web_driver():
+        if not self.reuse_selenium_web_driver():
             opts = selenium.webdriver.firefox.options.Options()
             opts.add_argument("-headless")
             self.driver = webdriver.Firefox(options=opts)
@@ -68,13 +68,13 @@ class AbstractWebTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        if cls.resue_selenium_web_driver():
+        if cls.reuse_selenium_web_driver():
             opts = selenium.webdriver.firefox.options.Options()
             opts.add_argument("-headless")
             cls.driver = webdriver.Firefox(options=opts)
 
     def tearDown(self) -> None:
-        if not self.resue_selenium_web_driver():
+        if not self.reuse_selenium_web_driver():
             self.driver.close()
             self.driver.quit()
 
@@ -82,12 +82,12 @@ class AbstractWebTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        if cls.resue_selenium_web_driver():
+        if cls.reuse_selenium_web_driver():
             cls.driver.close()
             cls.driver.quit()
 
     @staticmethod
-    def resue_selenium_web_driver() -> bool:
+    def reuse_selenium_web_driver() -> bool:
         """Determine whether the selenium driver shall be shared between all consecutive tests in this class.
 
         Checks whether the environment variable SHC_TEST_REUSE_WEB_DRIVER is set.


### PR DESCRIPTION
Sharing the selenium driver in the web tests is now optional.  Since sharing the web driver causes concurrency issues on e.g. WSL it can now be configured by setting the environment variable `SHARE_SELENIUM_WEB_DRIVER`.  

Running on WSL defaults to not share the driver but can be overwritten w/ above environment variable.

All other OS will share the driver by default unless `SHARE_SELENIUM_WEB_DRIVER` is set to True.